### PR TITLE
Fix typos in documentation files

### DIFF
--- a/lm_eval/tasks/galician_bench/README.md
+++ b/lm_eval/tasks/galician_bench/README.md
@@ -2,7 +2,7 @@
 
 ### Paper
 
-GalicianBench is a benchmark for evaluating language models in Galician tasks. This is, it evaluates the ability of a language model to understand and generate Galician text. GalicianBench offers a combination of pre-existing, open datasets and datasets developed exclusivelly for this benchmark. All the details of GalicianBench will be published in a paper soon.
+GalicianBench is a benchmark for evaluating language models in Galician tasks. This is, it evaluates the ability of a language model to understand and generate Galician text. GalicianBench offers a combination of pre-existing, open datasets and datasets developed exclusively for this benchmark. All the details of GalicianBench will be published in a paper soon.
 
 The new evaluation datasets included in GalicianBench are:
 | Task          | Category       | Homepage  |

--- a/lm_eval/tasks/leaderboard/ifeval/instructions.py
+++ b/lm_eval/tasks/leaderboard/ifeval/instructions.py
@@ -1161,7 +1161,7 @@ class RephraseParagraph(Instruction):
 
         Args:
           original_paragraph: A string presenting the original paragraph. The
-            rephrases response should have betweeb low-high words in common.
+            rephrases response should have between low-high words in common.
           low: An integer presenting the lower bound of similar words.
           high: An integer representing the upper bound of similar words.
 

--- a/lm_eval/tasks/score/NON_GREEDY.md
+++ b/lm_eval/tasks/score/NON_GREEDY.md
@@ -16,7 +16,7 @@ limitations under the License.
 # Non Greedy Evaluation
 
 This task checks for model's consistency towards seed changes during generation.
-More particularly it evaluates the model's accuracy and consistancy rate with 5
+More particularly it evaluates the model's accuracy and consistency rate with 5
 different seeds (seed = 1, 2,...,5) for a fixed prompt with temperature set to 0.7.
 
 ## How to run the Non-Greedy evaluation of SCORE?
@@ -35,7 +35,7 @@ To run the evaluation of the Non-Greedy tasks with 5 different seeds you should:
 
 3. When all 5 runs are finished and logs are saved, run the `./lm_eval/tasks/score/non_greedy_summarizer.py` script by passing the the output directory of the above runs to the `--log_dir` argument***, and by specifying the dataset name for which the evaluations were run with `--dataset` argument(`agieval`, `mmlu_pro` or `math`). \
 
-4. The script will return the default lm_evaluation_harness table where accuracies for each seed and the consistancy rate are calculated.
+4. The script will return the default lm_evaluation_harness table where accuracies for each seed and the consistency rate are calculated.
 
 
 \* _As this evaluation requires `--log_samples` to be True, it will need some extra disk space to save the prediction results for each seed._


### PR DESCRIPTION
This PR fixes several typos in documentation files:

- Fixes spelling of "between" in instructions.py
- Fixes spelling of "consistency" in NON_GREEDY.md
- Improves text formatting in galician_bench/README.md

These changes are minor text corrections that improve readability of the documentation without changing any functionality.